### PR TITLE
Update the superagent package to 3.8.1 (Security)

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "fs": false
   },
   "dependencies": {
-    "superagent": "3.7.0",
+    "superagent": "3.8.1",
     "dotenv": "^8.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Snyk has detected a vulnerability issue regarding the superagent package 3.7.0, and its suggestion was to update superagent to 3.8.1 to avoid any security issues.
![image](https://user-images.githubusercontent.com/29688758/95839285-20d91680-0d43-11eb-8c1a-32fc7a0c927d.png)
