### PR TITLE
Latest update broke imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mailchimp/mailchimp_marketing",
   "version": "3.0.42",
-  "description": "The official Node client library for the Mailchimp Marketing API",
+  "description": "The official Node client library for the Mailchimp Marketing API Sorry for doing this",
   "license": "Apache 2.0",
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
I'm sorry for doing this, but because issues are turned off, there isn't a good way for me to let you know that the latest update to 3.0.42 broke the library. 

Upon importing the package you now get an error.

```
exports.prototype.setConfig = function(config = {}) {
                  ^
TypeError: Cannot set property 'setConfig' of undefined
    at node_modules/@mailchimp/mailchimp_marketing/src/ApiClient.js (/Users/scotttolinski/Sites/levelup/api/node_modules/@mailchimp/mailchimp_marketing/src/ApiClient.js:144:19)
    at __require (/Users/scotttolinski/Sites/levelup/api/dist/index.js:9:44)
    at node_modules/@mailchimp/mailchimp_marketing/src/index.js (/Users/scotttolinski/Sites/levelup/api/node_modules/@mailchimp/mailchimp_marketing/src/index.js:1:17)
    at __require (/Users/scotttolinski/Sites/levelup/api/dist/index.js:9:44)
    at Object.<anonymous> (/Users/scotttolinski/Sites/levelup/api/src/users/methods.ts:4:23)
    at Module._compile (node:internal/modules/cjs/loader:1108:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1137:10)
    at Module.load (node:internal/modules/cjs/loader:973:32)
    at Function.Module._load (node:internal/modules/cjs/loader:813:14)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:76:12)
    at main (/Users/scotttolinski/Sites/levelup/api/node_modules/ts-node/src/bin.ts:198:14)
    at Object.<anonymous> (/Users/scotttolinski/Sites/levelup/api/node_modules/ts-node/src/bin.ts:288:3)
    at Module._compile (node:internal/modules/cjs/loader:1108:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1137:10)
    at Module.load (node:internal/modules/cjs/loader:973:32)
    at Function.Module._load (node:internal/modules/cjs/loader:813:14)
```

I know this could be seen as abuse of the PR functionality but I wasn't sure how else to let ya'll know.