### PR TITLE
Udapte superagent package

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "fs": false
   },
   "dependencies": {
-    "superagent": "3.7.0",
+    "superagent": "3.8.1",
     "dotenv": "^8.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Prevent authorization headers to be sent on the request, it was fixed on version 3.8.1

Issue: https://github.com/visionmedia/superagent/issues/1309